### PR TITLE
Add SQRT(...) operator

### DIFF
--- a/pkg/gooq/expression.go
+++ b/pkg/gooq/expression.go
@@ -444,6 +444,7 @@ type NumericExpression interface {
 	Sub(rhs NumericExpression) NumericExpression
 	Mult(rhs NumericExpression) NumericExpression
 	Div(rhs NumericExpression) NumericExpression
+	Sqrt() NumericExpression
 }
 
 type numericExpressionImpl struct {
@@ -455,6 +456,14 @@ func NewBinaryNumericExpressionImpl(
 ) NumericExpression {
 	instance := &numericExpressionImpl{}
 	instance.expressionImpl.initBinaryExpression(operator, lhs, rhs)
+	return instance
+}
+
+func NewUnaryPrefixNumericExpressionImpl(
+	operator Operator, operand NumericExpression,
+) NumericExpression {
+	instance := &numericExpressionImpl{}
+	instance.expressionImpl.initUnaryPrefixExpression(operator, operand)
 	return instance
 }
 
@@ -472,6 +481,10 @@ func (expr *numericExpressionImpl) Mult(rhs NumericExpression) NumericExpression
 
 func (expr *numericExpressionImpl) Div(rhs NumericExpression) NumericExpression {
 	return NewBinaryNumericExpressionImpl(OperatorDiv, expr, rhs)
+}
+
+func (expr *numericExpressionImpl) Sqrt() NumericExpression {
+	return NewUnaryPrefixNumericExpressionImpl(OperatorSqrt, expr)
 }
 
 func (expr *numericExpressionImpl) IsIn(value ...float64) BoolExpression {

--- a/pkg/gooq/expression_test.go
+++ b/pkg/gooq/expression_test.go
@@ -130,6 +130,26 @@ var expressionTestCases = []TestCase{
 		ExpectedStmt: "table1.uuid_column NOT IN ($1, $2)",
 		Arguments:    []interface{}{uuid.Nil, uuid.Nil},
 	},
+	{
+		Constructed:  Table1.DecimalColumn.Add(Int64(42)),
+		ExpectedStmt: "table1.decimal_column + $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Sub(Int64(-42)),
+		ExpectedStmt: "table1.decimal_column - $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Mult(Int64(42)),
+		ExpectedStmt: "table1.decimal_column * $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Div(Int64(0)),
+		ExpectedStmt: "table1.decimal_column / $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Sqrt(),
+		ExpectedStmt: "|/ table1.decimal_column",
+	},
 }
 
 func TestExpressions(t *testing.T) {

--- a/pkg/gooq/expression_test.go
+++ b/pkg/gooq/expression_test.go
@@ -73,6 +73,26 @@ var expressionTestCases = []TestCase{
 		ExpectedStmt: "table1.decimal_column != $1",
 	},
 	{
+		Constructed:  Table1.DecimalColumn.Add(Int64(42)),
+		ExpectedStmt: "table1.decimal_column + $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Sub(Int64(-42)),
+		ExpectedStmt: "table1.decimal_column - $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Mult(Int64(42)),
+		ExpectedStmt: "table1.decimal_column * $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Div(Int64(0)),
+		ExpectedStmt: "table1.decimal_column / $1",
+	},
+	{
+		Constructed:  Table1.DecimalColumn.Sqrt(),
+		ExpectedStmt: "|/ table1.decimal_column",
+	},
+	{
 		Constructed:  Table1.StringColumn.IsEq("foo"),
 		ExpectedStmt: "table1.string_column = $1",
 	},
@@ -129,26 +149,6 @@ var expressionTestCases = []TestCase{
 		Constructed:  Table1.UUIDColumn.IsNotIn(uuid.Nil, uuid.Nil),
 		ExpectedStmt: "table1.uuid_column NOT IN ($1, $2)",
 		Arguments:    []interface{}{uuid.Nil, uuid.Nil},
-	},
-	{
-		Constructed:  Table1.DecimalColumn.Add(Int64(42)),
-		ExpectedStmt: "table1.decimal_column + $1",
-	},
-	{
-		Constructed:  Table1.DecimalColumn.Sub(Int64(-42)),
-		ExpectedStmt: "table1.decimal_column - $1",
-	},
-	{
-		Constructed:  Table1.DecimalColumn.Mult(Int64(42)),
-		ExpectedStmt: "table1.decimal_column * $1",
-	},
-	{
-		Constructed:  Table1.DecimalColumn.Div(Int64(0)),
-		ExpectedStmt: "table1.decimal_column / $1",
-	},
-	{
-		Constructed:  Table1.DecimalColumn.Sqrt(),
-		ExpectedStmt: "|/ table1.decimal_column",
 	},
 }
 

--- a/pkg/gooq/operator.go
+++ b/pkg/gooq/operator.go
@@ -31,6 +31,7 @@ var (
 	OperatorSub  = Operator("-")
 	OperatorMult = Operator("*")
 	OperatorDiv  = Operator("/")
+	OperatorSqrt = Operator("|/")
 
 	// Table 9.13. Bit String Operators
 	// https://www.postgresql.org/docs/11/functions-bitstring.html


### PR DESCRIPTION
Adds support for the square root operator (`|/`).

As a side note,

Why is `NewBinaryNumericExpressionImpl` exported? I couldn't find any usages outside of the package. I made `NewUnaryPrefixNumericExpressionImpl` exported too for consistency, but there are other implementations such as `newBinaryBooleanExpressionImpl` that are not exported.

## References

* Issue: https://github.com/lumina-tech/gOOQ/issues/6
* Documentation: https://www.postgresql.org/docs/11/functions-math.html