### PR TITLE
add ASCII, B/L/RTRIM string functions

### DIFF
--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -104,6 +104,12 @@ func (expr *expressionFunctionImpl) Render(
 // [Good First Issue][Help Wanted] TODO: implement remaining functions (not operators)
 ///////////////////////////////////////////////////////////////////////////////
 
+func Ascii(
+	text string,
+) Expression {
+	return NewExpressionFunction("ASCII", String(text))
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -105,13 +105,13 @@ func (expr *expressionFunctionImpl) Render(
 ///////////////////////////////////////////////////////////////////////////////
 
 func Ascii(
-	input Expression,
+	input StringExpression,
 ) Expression {
 	return NewExpressionFunction("ASCII", input)
 }
 
 func BTrim(
-	source Expression, characters ...Expression,
+	source StringExpression, characters ...StringExpression,
 ) Expression {
 	expressions := []Expression{source}
 	if characters != nil {
@@ -121,7 +121,7 @@ func BTrim(
 }
 
 func LTrim(
-	source Expression, characters ...Expression,
+	source StringExpression, characters ...StringExpression,
 ) Expression {
 	expressions := []Expression{source}
 	if characters != nil {
@@ -131,7 +131,7 @@ func LTrim(
 }
 
 func RTrim(
-	source Expression, characters ...Expression,
+	source StringExpression, characters ...StringExpression,
 ) Expression {
 	expressions := []Expression{source}
 	if characters != nil {

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -105,37 +105,37 @@ func (expr *expressionFunctionImpl) Render(
 ///////////////////////////////////////////////////////////////////////////////
 
 func Ascii(
-	text string,
+	input Expression,
 ) Expression {
-	return NewExpressionFunction("ASCII", String(text))
+	return NewExpressionFunction("ASCII", input)
 }
 
 func BTrim(
-	text string, characters ...string,
+	source Expression, characters ...Expression,
 ) Expression {
-	expressions := []Expression{String(text)}
+	expressions := []Expression{source}
 	if characters != nil {
-		expressions = append(expressions, String(characters[0]))
+		expressions = append(expressions, characters[0])
 	}
 	return NewExpressionFunction("BTRIM", expressions...)
 }
 
 func LTrim(
-	text string, characters ...string,
+	source Expression, characters ...Expression,
 ) Expression {
-	expressions := []Expression{String(text)}
+	expressions := []Expression{source}
 	if characters != nil {
-		expressions = append(expressions, String(characters[0]))
+		expressions = append(expressions, characters[0])
 	}
 	return NewExpressionFunction("LTRIM", expressions...)
 }
 
 func RTrim(
-	text string, characters ...string,
+	source Expression, characters ...Expression,
 ) Expression {
-	expressions := []Expression{String(text)}
+	expressions := []Expression{source}
 	if characters != nil {
-		expressions = append(expressions, String(characters[0]))
+		expressions = append(expressions, characters[0])
 	}
 	return NewExpressionFunction("RTRIM", expressions...)
 }

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -110,6 +110,36 @@ func Ascii(
 	return NewExpressionFunction("ASCII", String(text))
 }
 
+func BTrim(
+	text string, characters ...string,
+) Expression {
+	expressions := []Expression{String(text)}
+	if characters != nil {
+		expressions = append(expressions, String(characters[0]))
+	}
+	return NewExpressionFunction("BTRIM", expressions...)
+}
+
+func LTrim(
+	text string, characters ...string,
+) Expression {
+	expressions := []Expression{String(text)}
+	if characters != nil {
+		expressions = append(expressions, String(characters[0]))
+	}
+	return NewExpressionFunction("LTRIM", expressions...)
+}
+
+func RTrim(
+	text string, characters ...string,
+) Expression {
+	expressions := []Expression{String(text)}
+	if characters != nil {
+		expressions = append(expressions, String(characters[0]))
+	}
+	return NewExpressionFunction("RTRIM", expressions...)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -27,6 +27,18 @@ var functionTestCases = []TestCase{
 		Constructed:  Ascii("abc"),
 		ExpectedStmt: "ASCII($1)",
 	},
+	{
+		Constructed:  BTrim("    abc    "),
+		ExpectedStmt: "BTRIM($1)",
+	},
+	{
+		Constructed:  LTrim("xyzxyzabcxyz", "xyz"),
+		ExpectedStmt: "LTRIM($1, $2)",
+	},
+	{
+		Constructed:  RTrim("xyzxyzabcxyz", "xyz", "disregarded"),
+		ExpectedStmt: "RTRIM($1, $2)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -23,6 +23,10 @@ var functionTestCases = []TestCase{
 		Constructed:  Least(String("a"), String("b")),
 		ExpectedStmt: "LEAST($1, $2)",
 	},
+	{
+		Constructed:  Ascii("abc"),
+		ExpectedStmt: "ASCII($1)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -24,20 +24,24 @@ var functionTestCases = []TestCase{
 		ExpectedStmt: "LEAST($1, $2)",
 	},
 	{
-		Constructed:  Ascii("abc"),
+		Constructed:  Ascii(String("abc")),
 		ExpectedStmt: "ASCII($1)",
 	},
 	{
-		Constructed:  BTrim("    abc    "),
+		Constructed:  Ascii(Table1.Column1),
+		ExpectedStmt: "ASCII(table1.column1)",
+	},
+	{
+		Constructed:  BTrim(String("    abc    ")),
 		ExpectedStmt: "BTRIM($1)",
 	},
 	{
-		Constructed:  LTrim("xyzxyzabcxyz", "xyz"),
-		ExpectedStmt: "LTRIM($1, $2)",
+		Constructed:  LTrim(Table1.Column1, String("xyz")),
+		ExpectedStmt: "LTRIM(table1.column1, $1)",
 	},
 	{
-		Constructed:  RTrim("xyzxyzabcxyz", "xyz", "disregarded"),
-		ExpectedStmt: "RTRIM($1, $2)",
+		Constructed:  RTrim(String("xyzxyzabcxyz"), Table1.Column1),
+		ExpectedStmt: "RTRIM($1, table1.column1)",
 	},
 }
 


### PR DESCRIPTION
Adds support for the ascii and both/left/right trim string manipulation functions in table 9.9 of the documentation.

## References
- Issue: #7 
- Documentation: https://www.postgresql.org/docs/11/functions-string.html#FUNCTIONS-STRING-OTHER