### PR TITLE
enforce return types on ascii, b/l/rtrim

### DIFF
--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -160,13 +160,13 @@ func (expr *stringExpressionFunctionImpl) Render(
 
 func Ascii(
 	input StringExpression,
-) Expression {
-	return NewStringExpressionFunction("ASCII", input)
+) NumericExpression {
+	return NewNumericExpressionFunction("ASCII", input)
 }
 
 func BTrim(
 	source StringExpression, characters ...StringExpression,
-) Expression {
+) StringExpression {
 	expressions := []Expression{source}
 	if characters != nil {
 		expressions = append(expressions, characters[0])
@@ -176,7 +176,7 @@ func BTrim(
 
 func LTrim(
 	source StringExpression, characters ...StringExpression,
-) Expression {
+) StringExpression {
 	expressions := []Expression{source}
 	if characters != nil {
 		expressions = append(expressions, characters[0])
@@ -186,7 +186,7 @@ func LTrim(
 
 func RTrim(
 	source StringExpression, characters ...StringExpression,
-) Expression {
+) StringExpression {
 	expressions := []Expression{source}
 	if characters != nil {
 		expressions = append(expressions, characters[0])


### PR DESCRIPTION
Enforces the return types of ascii and both/left/right trim string manipulation functions.

## References
- Documentation: https://www.postgresql.org/docs/11/functions-string.html#FUNCTIONS-STRING-OTHER