### PR TITLE
add BoolExpressionFunction type and starts_with string function

### DIFF
--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -137,6 +137,32 @@ func (expr *stringExpressionFunctionImpl) Render(
 	builder.Printf(")")
 }
 
+type boolExpressionFunctionImpl struct {
+	boolExpressionImpl
+	name string
+}
+
+func NewBoolExpressionFunction(
+	name string, arguments ...Expression,
+) BoolExpression {
+	function := &boolExpressionFunctionImpl{name: name}
+	function.expressionImpl.initFunctionExpression(function, arguments...)
+	return function
+}
+
+func (expr *boolExpressionFunctionImpl) Render(
+	builder *Builder,
+) {
+	builder.Printf("%s(", expr.name)
+	for index, argument := range expr.expressions {
+		argument.Render(builder)
+		if index != len(expr.expressions)-1 {
+			builder.Print(", ")
+		}
+	}
+	builder.Printf(")")
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.3. Comparison Functions
 // https://www.postgresql.org/docs/11/functions-comparison.html

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -220,6 +220,12 @@ func RTrim(
 	return NewStringExpressionFunction("RTRIM", expressions...)
 }
 
+func StartsWith(
+	text StringExpression, prefix StringExpression,
+) BoolExpression {
+	return NewBoolExpressionFunction("STARTS_WITH", text, prefix)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -43,6 +43,10 @@ var functionTestCases = []TestCase{
 		Constructed:  RTrim(String("xyzxyzabcxyz"), Table1.Column1),
 		ExpectedStmt: "RTRIM($1, table1.column1)",
 	},
+	{
+		Constructed:  StartsWith(String("alphabet"), String("alph")),
+		ExpectedStmt: "STARTS_WITH($1, $2)",
+	},
 }
 
 func TestFunctions(t *testing.T) {


### PR DESCRIPTION
Adds support for expression functions returning booleans and the starts_with string function in table 9.9 of the documentation.

## References
- Issue: #7 
- Documentation: https://www.postgresql.org/docs/11/functions-string.html#FUNCTIONS-STRING-OTHER