### PR TITLE
add string functions in table 9.9

### DIFF
--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -355,7 +355,7 @@ func Replace(
 }
 
 func Reverse(
-	text Expression,
+	text StringExpression,
 ) StringExpression {
 	return NewStringExpressionFunction("REVERSE", text)
 }

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -375,7 +375,16 @@ func Strpos(
 
 // TODO: Substr, StartsWith
 
-// TODO: ToAscii
+func ToAscii(
+	text StringExpression, encoding ...StringExpression,
+) StringExpression {
+	arguments := []Expression{text}
+	if encoding != nil {
+		arguments = append(arguments, encoding[0])
+	}
+	// TODO: enforce encoding to be one of {LATIN1, LATIN2, LATIN9, WIN1250}
+	return NewStringExpressionFunction("TO_ASCII", arguments...)
+}
 
 func ToHex(
 	number NumericExpression,

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -285,6 +285,28 @@ func Length(
 	return NewNumericExpressionFunction("LENGTH", arguments...)
 }
 
+func LPad(
+	text StringExpression, len NumericExpression,
+	fill ...StringExpression,
+) StringExpression {
+	arguments := []Expression{text, len}
+	if fill != nil {
+		arguments = append(arguments, fill[0])
+	}
+	return NewStringExpressionFunction("LPAD", arguments...)
+}
+
+func RPad(
+	text StringExpression, len NumericExpression,
+	fill ...StringExpression,
+) StringExpression {
+	arguments := []Expression{text, len}
+	if fill != nil {
+		arguments = append(arguments, fill[0])
+	}
+	return NewStringExpressionFunction("RPAD", arguments...)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -248,6 +248,8 @@ func ConcatWs(
 	return NewStringExpressionFunction("CONCAT_WS", expressions...)
 }
 
+// TODO: Convert, ConvertFrom, ConvertTo, Decode, Encode
+
 func Format(
 	formatStr StringExpression, formatArg ...Expression,
 ) StringExpression {
@@ -313,6 +315,8 @@ func Md5(
 	return NewStringExpressionFunction("MD5", text)
 }
 
+// TODO: ParseIdent
+
 func PgClientEncoding() StringExpression {
 	return NewStringExpressionFunction("PG_CLIENT_ENCODING")
 }
@@ -335,6 +339,9 @@ func QuoteNullable(
 	return NewStringExpressionFunction("QUOTE_NULLABLE", value)
 }
 
+// TODO: RegexpMatch, RegexpMatches, RegexpReplace,
+// 		 RegexpSplitToArray, RegexpSplitToTable
+
 func Repeat(
 	text StringExpression, n NumericExpression,
 ) StringExpression {
@@ -352,6 +359,8 @@ func Reverse(
 ) StringExpression {
 	return NewStringExpressionFunction("REVERSE", text)
 }
+
+// TODO: SplitPart, Strpos, Substr, StartsWith, ToAscii, ToHex, Translate
 
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -335,6 +335,24 @@ func QuoteNullable(
 	return NewStringExpressionFunction("QUOTE_NULLABLE", value)
 }
 
+func Repeat(
+	text StringExpression, n NumericExpression,
+) StringExpression {
+	return NewStringExpressionFunction("REPEAT", text, n)
+}
+
+func Replace(
+	text StringExpression, from StringExpression, to StringExpression,
+) StringExpression {
+	return NewStringExpressionFunction("REPLACE", text, from, to)
+}
+
+func Reverse(
+	text Expression,
+) StringExpression {
+	return NewStringExpressionFunction("REVERSE", text)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -258,6 +258,12 @@ func Format(
 	return NewStringExpressionFunction("FORMAT", expressions...)
 }
 
+func InitCap(
+	text StringExpression,
+) StringExpression {
+	return NewStringExpressionFunction("INITCAP", text)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -226,6 +226,20 @@ func StartsWith(
 	return NewBoolExpressionFunction("STARTS_WITH", text, prefix)
 }
 
+func Chr(
+	asciiCode NumericExpression,
+) Expression {
+	// TODO: add strict checking on asciiCode (i.e. make sure is not 0)
+	return NewExpressionFunction("CHR", asciiCode)
+}
+
+func Concat(
+	text Expression, moreText ...Expression,
+) Expression {
+	expressions := append([]Expression{text}, moreText...)
+	return NewExpressionFunction("CONCAT", expressions...)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -307,6 +307,34 @@ func RPad(
 	return NewStringExpressionFunction("RPAD", arguments...)
 }
 
+func Md5(
+	text StringExpression,
+) StringExpression {
+	return NewStringExpressionFunction("MD5", text)
+}
+
+func PgClientEncoding() StringExpression {
+	return NewStringExpressionFunction("PG_CLIENT_ENCODING")
+}
+
+func QuoteIdent(
+	text StringExpression,
+) StringExpression {
+	return NewStringExpressionFunction("QUOTE_IDENT", text)
+}
+
+func QuoteLiteral(
+	value Expression,
+) StringExpression {
+	return NewStringExpressionFunction("QUOTE_LITERAL", value)
+}
+
+func QuoteNullable(
+	value Expression,
+) StringExpression {
+	return NewStringExpressionFunction("QUOTE_NULLABLE", value)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -360,7 +360,36 @@ func Reverse(
 	return NewStringExpressionFunction("REVERSE", text)
 }
 
-// TODO: SplitPart, Strpos, Substr, StartsWith, ToAscii, ToHex, Translate
+func SplitPart(
+	text StringExpression, delimiter StringExpression,
+	field NumericExpression,
+) StringExpression {
+	return NewStringExpressionFunction("SPLIT_PART", text, delimiter, field)
+}
+
+func Strpos(
+	text StringExpression, substring StringExpression,
+) NumericExpression {
+	return NewNumericExpressionFunction("STRPOS", text, substring)
+}
+
+// TODO: Substr, StartsWith
+
+// TODO: ToAscii
+
+func ToHex(
+	number NumericExpression,
+) StringExpression {
+	// TODO: enforce integer requirement on number
+	// (either int or bigint, but not decimal)
+	return NewStringExpressionFunction("TO_HEX", number)
+}
+
+func Translate(
+	text StringExpression, from StringExpression, to StringExpression,
+) StringExpression {
+	return NewStringExpressionFunction("TRANSLATE", text, from, to)
+}
 
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -264,6 +264,18 @@ func InitCap(
 	return NewStringExpressionFunction("INITCAP", text)
 }
 
+func Left(
+	text StringExpression, n NumericExpression,
+) StringExpression {
+	return NewStringExpressionFunction("LEFT", text, n)
+}
+
+func Right(
+	text StringExpression, n NumericExpression,
+) StringExpression {
+	return NewStringExpressionFunction("RIGHT", text, n)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -220,12 +220,6 @@ func RTrim(
 	return NewStringExpressionFunction("RTRIM", expressions...)
 }
 
-func StartsWith(
-	text StringExpression, prefix StringExpression,
-) BoolExpression {
-	return NewBoolExpressionFunction("STARTS_WITH", text, prefix)
-}
-
 func Chr(
 	asciiCode NumericExpression,
 ) StringExpression {
@@ -384,7 +378,11 @@ func Substr(
 	return NewStringExpressionFunction("SUBSTR", arguments...)
 }
 
-// TODO: StartsWith
+func StartsWith(
+	text StringExpression, prefix StringExpression,
+) BoolExpression {
+	return NewBoolExpressionFunction("STARTS_WITH", text, prefix)
+}
 
 func ToAscii(
 	text StringExpression, encoding ...StringExpression,

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -275,6 +275,16 @@ func Right(
 	return NewStringExpressionFunction("RIGHT", text, n)
 }
 
+func Length(
+	text StringExpression, encoding ...StringExpression,
+) NumericExpression {
+	arguments := []Expression{text}
+	if encoding != nil {
+		arguments = append(arguments, encoding[0])
+	}
+	return NewNumericExpressionFunction("LENGTH", arguments...)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -228,16 +228,16 @@ func StartsWith(
 
 func Chr(
 	asciiCode NumericExpression,
-) Expression {
+) StringExpression {
 	// TODO: add strict checking on asciiCode (i.e. make sure is not 0)
-	return NewExpressionFunction("CHR", asciiCode)
+	return NewStringExpressionFunction("CHR", asciiCode)
 }
 
 func Concat(
 	text Expression, moreText ...Expression,
-) Expression {
+) StringExpression {
 	expressions := append([]Expression{text}, moreText...)
-	return NewExpressionFunction("CONCAT", expressions...)
+	return NewStringExpressionFunction("CONCAT", expressions...)
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -240,6 +240,15 @@ func Concat(
 	return NewStringExpressionFunction("CONCAT", expressions...)
 }
 
+func ConcatWs(
+	separator StringExpression,
+	text Expression, moreText ...Expression,
+) StringExpression {
+	expressions := append([]Expression{separator}, text)
+	expressions = append(expressions, moreText...)
+	return NewStringExpressionFunction("CONCAT_WS", expressions...)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -373,7 +373,18 @@ func Strpos(
 	return NewNumericExpressionFunction("STRPOS", text, substring)
 }
 
-// TODO: Substr, StartsWith
+func Substr(
+	text StringExpression, from NumericExpression,
+	count ...NumericExpression,
+) StringExpression {
+	arguments := []Expression{text, from}
+	if count != nil {
+		arguments = append(arguments, count[0])
+	}
+	return NewStringExpressionFunction("SUBSTR", arguments...)
+}
+
+// TODO: StartsWith
 
 func ToAscii(
 	text StringExpression, encoding ...StringExpression,

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -249,6 +249,15 @@ func ConcatWs(
 	return NewStringExpressionFunction("CONCAT_WS", expressions...)
 }
 
+func Format(
+	formatStr StringExpression, formatArg ...Expression,
+) StringExpression {
+	// TODO: enforce checking on number of formatArgs
+	// (i.e. make sure is the same as the number of elements to be replaced in formatStr)
+	expressions := append([]Expression{formatStr}, formatArg...)
+	return NewStringExpressionFunction("FORMAT", expressions...)
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 // Table 9.11. SQL Binary String Functions and Operators
 // Table 9.12. Other Binary String Functions

--- a/pkg/gooq/function.go
+++ b/pkg/gooq/function.go
@@ -244,8 +244,7 @@ func ConcatWs(
 	separator StringExpression,
 	text Expression, moreText ...Expression,
 ) StringExpression {
-	expressions := append([]Expression{separator}, text)
-	expressions = append(expressions, moreText...)
+	expressions := append([]Expression{separator, text}, moreText...)
 	return NewStringExpressionFunction("CONCAT_WS", expressions...)
 }
 

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -140,6 +140,14 @@ var functionTestCases = []TestCase{
 		ExpectedStmt: "STRPOS(table1.column1, $1)",
 	},
 	{
+		Constructed:  ToAscii(Table1.Column1),
+		ExpectedStmt: "TO_ASCII(table1.column1)",
+	},
+	{
+		Constructed:  ToAscii(String("Karel"), String("WIN1250")),
+		ExpectedStmt: "TO_ASCII($1, $2)",
+	},
+	{
 		Constructed:  ToHex(Table1.Column3),
 		ExpectedStmt: "TO_HEX(table1.column3)",
 	},

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -55,6 +55,10 @@ var functionTestCases = []TestCase{
 		Constructed:  Concat(String("xyzxyzabcxyz"), Table1.Column3, Int64(3)),
 		ExpectedStmt: "CONCAT($1, table1.column3, $2)",
 	},
+	{
+		Constructed:  ConcatWs(String("x"), Table1.Column3, Int64(3), String("four")),
+		ExpectedStmt: "CONCAT_WS($1, table1.column3, $2, $3)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -59,6 +59,14 @@ var functionTestCases = []TestCase{
 		Constructed:  ConcatWs(String("x"), Table1.Column3, Int64(3), String("four")),
 		ExpectedStmt: "CONCAT_WS($1, table1.column3, $2, $3)",
 	},
+	{
+		Constructed:  Format(String("Hello %s, %1$s"), Table1.Column3),
+		ExpectedStmt: "FORMAT($1, table1.column3)",
+	},
+	{
+		Constructed:  Format(String("no formatting to be done")),
+		ExpectedStmt: "FORMAT($1)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -131,6 +131,22 @@ var functionTestCases = []TestCase{
 		Constructed:  Reverse(String("reversable")),
 		ExpectedStmt: "REVERSE($1)",
 	},
+	{
+		Constructed:  SplitPart(String("abc~@~def~@~ghi"), String("~@~"), Int64(2)),
+		ExpectedStmt: "SPLIT_PART($1, $2, $3)",
+	},
+	{
+		Constructed:  Strpos(Table1.Column1, String("ab")),
+		ExpectedStmt: "STRPOS(table1.column1, $1)",
+	},
+	{
+		Constructed:  ToHex(Table1.Column3),
+		ExpectedStmt: "TO_HEX(table1.column3)",
+	},
+	{
+		Constructed:  Translate(String("12345"), String("143"), String("ax")),
+		ExpectedStmt: "TRANSLATE($1, $2, $3)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -79,6 +79,14 @@ var functionTestCases = []TestCase{
 		Constructed:  Right(String("take my right chars"), Table1.Column3),
 		ExpectedStmt: "RIGHT($1, table1.column3)",
 	},
+	{
+		Constructed:  Length(Table1.Column1),
+		ExpectedStmt: "LENGTH(table1.column1)",
+	},
+	{
+		Constructed:  Length(String("jose"), String("UTF8")),
+		ExpectedStmt: "LENGTH($1, $2)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -47,6 +47,14 @@ var functionTestCases = []TestCase{
 		Constructed:  StartsWith(String("alphabet"), String("alph")),
 		ExpectedStmt: "STARTS_WITH($1, $2)",
 	},
+	{
+		Constructed:  Chr(Table1.Column3),
+		ExpectedStmt: "CHR(table1.column3)",
+	},
+	{
+		Constructed:  Concat(String("xyzxyzabcxyz"), Table1.Column3, Int64(3)),
+		ExpectedStmt: "CONCAT($1, table1.column3, $2)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -44,10 +44,6 @@ var functionTestCases = []TestCase{
 		ExpectedStmt: "RTRIM($1, table1.column1)",
 	},
 	{
-		Constructed:  StartsWith(String("alphabet"), String("alph")),
-		ExpectedStmt: "STARTS_WITH($1, $2)",
-	},
-	{
 		Constructed:  Chr(Table1.Column3),
 		ExpectedStmt: "CHR(table1.column3)",
 	},
@@ -142,6 +138,10 @@ var functionTestCases = []TestCase{
 	{
 		Constructed:  Substr(Table1.Column1, Int64(2), Int64(5)),
 		ExpectedStmt: "SUBSTR(table1.column1, $1, $2)",
+	},
+	{
+		Constructed:  StartsWith(String("alphabet"), String("alph")),
+		ExpectedStmt: "STARTS_WITH($1, $2)",
 	},
 	{
 		Constructed:  ToAscii(Table1.Column1),

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -87,6 +87,14 @@ var functionTestCases = []TestCase{
 		Constructed:  Length(String("jose"), String("UTF8")),
 		ExpectedStmt: "LENGTH($1, $2)",
 	},
+	{
+		Constructed:  LPad(String("hi"), Int64(7)),
+		ExpectedStmt: "LPAD($1, $2)",
+	},
+	{
+		Constructed:  RPad(Table1.Column2, Table1.Column3, Table1.Column1),
+		ExpectedStmt: "RPAD(table1.column2, table1.column3, table1.column1)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -67,6 +67,10 @@ var functionTestCases = []TestCase{
 		Constructed:  Format(String("no formatting to be done")),
 		ExpectedStmt: "FORMAT($1)",
 	},
+	{
+		Constructed:  InitCap(String("initCap THIS SenTEnce")),
+		ExpectedStmt: "INITCAP($1)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -71,6 +71,14 @@ var functionTestCases = []TestCase{
 		Constructed:  InitCap(String("initCap THIS SenTEnce")),
 		ExpectedStmt: "INITCAP($1)",
 	},
+	{
+		Constructed:  Left(Table1.Column1, Int64(3)),
+		ExpectedStmt: "LEFT(table1.column1, $1)",
+	},
+	{
+		Constructed:  Right(String("take my right chars"), Table1.Column3),
+		ExpectedStmt: "RIGHT($1, table1.column3)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -140,6 +140,10 @@ var functionTestCases = []TestCase{
 		ExpectedStmt: "STRPOS(table1.column1, $1)",
 	},
 	{
+		Constructed:  Substr(Table1.Column1, Int64(2), Int64(5)),
+		ExpectedStmt: "SUBSTR(table1.column1, $1, $2)",
+	},
+	{
 		Constructed:  ToAscii(Table1.Column1),
 		ExpectedStmt: "TO_ASCII(table1.column1)",
 	},

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -119,6 +119,18 @@ var functionTestCases = []TestCase{
 		Constructed:  QuoteNullable(Table3.UUIDColumn),
 		ExpectedStmt: "QUOTE_NULLABLE(table3.uuid_column)",
 	},
+	{
+		Constructed:  Repeat(String("abc"), Table1.Column3),
+		ExpectedStmt: "REPEAT($1, table1.column3)",
+	},
+	{
+		Constructed:  Replace(Table1.Column1, String("ab"), String("CD")),
+		ExpectedStmt: "REPLACE(table1.column1, $1, $2)",
+	},
+	{
+		Constructed:  Reverse(String("reversable")),
+		ExpectedStmt: "REVERSE($1)",
+	},
 }
 
 func TestFunctions(t *testing.T) {

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -95,6 +95,30 @@ var functionTestCases = []TestCase{
 		Constructed:  RPad(Table1.Column2, Table1.Column3, Table1.Column1),
 		ExpectedStmt: "RPAD(table1.column2, table1.column3, table1.column1)",
 	},
+	{
+		Constructed:  Md5(Table1.Column2),
+		ExpectedStmt: "MD5(table1.column2)",
+	},
+	{
+		Constructed:  PgClientEncoding(),
+		ExpectedStmt: "PG_CLIENT_ENCODING()",
+	},
+	{
+		Constructed:  QuoteIdent(String("foo bar")),
+		ExpectedStmt: "QUOTE_IDENT($1)",
+	},
+	{
+		Constructed:  QuoteLiteral(String("foo bar")),
+		ExpectedStmt: "QUOTE_LITERAL($1)",
+	},
+	{
+		Constructed:  QuoteLiteral(Float64(42.5)),
+		ExpectedStmt: "QUOTE_LITERAL($1)",
+	},
+	{
+		Constructed:  QuoteNullable(Table3.UUIDColumn),
+		ExpectedStmt: "QUOTE_NULLABLE(table3.uuid_column)",
+	},
 }
 
 func TestFunctions(t *testing.T) {


### PR DESCRIPTION
Adds support for the remaining functions in table 9.9 apart from convert functions (convert, convert_from, convert_to, decode, encode), parse_ident, and regexp functions (regexp_match, regexp_matches, regexp_replace, regexp_split_to_array, regexp_split_to_table).

|             |               |                |                    |
|-------------|---------------|----------------|--------------------|
| chr         | concat        | concat_ws      | format             |
| init_cap    | left          | right          | length             |
| lpad        | rpad          | md5            | pg_client_encoding |
| quote_ident | quote_literal | quote_nullable | repeat             |
| replace     | reverse       | split_part     | strpos             |
| substr      | to_ascii      | to_hex         | translate          |

## References
- Issue: #7 
- Documentation: https://www.postgresql.org/docs/11/functions-string.html#FUNCTIONS-STRING-OTHER