### PR TITLE
Fix TableImpl.As implementation

### DIFF
--- a/examples/swapi/table/swapi_table.generated.go
+++ b/examples/swapi/table/swapi_table.generated.go
@@ -40,7 +40,7 @@ func newColorReferenceTable() *colorReferenceTable {
 
 func (t *colorReferenceTable) As(alias string) *colorReferenceTable {
 	instance := newColorReferenceTable()
-	instance.TableImpl.As(alias)
+	instance.TableImpl = *instance.TableImpl.As(alias)
 	return instance
 }
 
@@ -118,7 +118,7 @@ func newPerson() *person {
 
 func (t *person) As(alias string) *person {
 	instance := newPerson()
-	instance.TableImpl.As(alias)
+	instance.TableImpl = *instance.TableImpl.As(alias)
 	return instance
 }
 
@@ -194,7 +194,7 @@ func newSpecies() *species {
 
 func (t *species) As(alias string) *species {
 	instance := newSpecies()
-	instance.TableImpl.As(alias)
+	instance.TableImpl = *instance.TableImpl.As(alias)
 	return instance
 }
 

--- a/pkg/generator/plugin/modelgen/template.go
+++ b/pkg/generator/plugin/modelgen/template.go
@@ -66,7 +66,7 @@ func new{{ capitalize $table.TableType }}() *{{ $table.TableType }} {
 
 func (t *{{ $table.TableType }}) As(alias string) *{{ $table.TableType }} {
   instance := new{{ $table.ModelType }}()
-  instance.TableImpl.As(alias)
+  instance.TableImpl = *instance.TableImpl.As(alias)
   return instance
 }
 

--- a/pkg/gooq/table.go
+++ b/pkg/gooq/table.go
@@ -31,8 +31,11 @@ func (t *TableImpl) Initialize(schema, name string) {
 }
 
 func (t *TableImpl) As(alias string) *TableImpl {
-	t.alias = null.StringFrom(alias)
-	return t
+	return &TableImpl{
+		name:   t.name,
+		schema: t.schema,
+		alias:  null.StringFrom(alias),
+	}
 }
 
 func (t TableImpl) GetAlias() null.String {


### PR DESCRIPTION
`As` should return a copy of the `TableImpl` with the alias set rather than updating the existing struct.