### PR TITLE
Always put quotes around the prefix for a field

### DIFF
--- a/pkg/gooq/delete_test.go
+++ b/pkg/gooq/delete_test.go
@@ -5,23 +5,23 @@ import "testing"
 var deleteTestCases = []TestCase{
 	{
 		Constructed:  Delete(Table1).Where(Table1.Column1.Eq(String("foo"))),
-		ExpectedStmt: `DELETE FROM public.table1 WHERE table1.column1 = $1`,
+		ExpectedStmt: `DELETE FROM public.table1 WHERE "table1".column1 = $1`,
 	},
 	{
 		Constructed:  Delete(Table1).Using(Table2).On(Table1.Column1.Eq(Table2.Column2)),
-		ExpectedStmt: `DELETE FROM public.table1 USING public.table2 WHERE table1.column1 = table2.column2`,
+		ExpectedStmt: `DELETE FROM public.table1 USING public.table2 WHERE "table1".column1 = "table2".column2`,
 	},
 	{
 		Constructed:  Delete(Table1).Using(Table2).On(Table1.Column1.Eq(Table2.Column2)).Where(Table1.Column1.Eq(String("foo"))),
-		ExpectedStmt: `DELETE FROM public.table1 USING public.table2 WHERE table1.column1 = table2.column2 AND table1.column1 = $1`,
+		ExpectedStmt: `DELETE FROM public.table1 USING public.table2 WHERE "table1".column1 = "table2".column2 AND "table1".column1 = $1`,
 	},
 	{
 		Constructed:  Delete(Table1).Using(Select().From(Table2).As("foo")).On(Table1.Column1.Eq(Table2.Column2)),
-		ExpectedStmt: `DELETE FROM public.table1 USING (SELECT * FROM public.table2) AS "foo" WHERE table1.column1 = table2.column2`,
+		ExpectedStmt: `DELETE FROM public.table1 USING (SELECT * FROM public.table2) AS "foo" WHERE "table1".column1 = "table2".column2`,
 	},
 	{
 		Constructed:  Delete(Table1).Where(Table1.Column1.Eq(String("foo"))).Returning(Table1.Column1),
-		ExpectedStmt: `DELETE FROM public.table1 WHERE table1.column1 = $1 RETURNING table1.column1`,
+		ExpectedStmt: `DELETE FROM public.table1 WHERE "table1".column1 = $1 RETURNING "table1".column1`,
 	},
 }
 

--- a/pkg/gooq/expression_test.go
+++ b/pkg/gooq/expression_test.go
@@ -10,153 +10,153 @@ import (
 var expressionTestCases = []TestCase{
 	{
 		Constructed:  Count(Table1.Column1),
-		ExpectedStmt: "COUNT(table1.column1)",
+		ExpectedStmt: `COUNT("table1".column1)`,
 	},
 	{
 		Constructed:  Count(Table1.Column1).IsGt(5),
-		ExpectedStmt: "COUNT(table1.column1) > $1",
+		ExpectedStmt: `COUNT("table1".column1) > $1`,
 		Arguments:    []interface{}{float64(5)},
 	},
 	{
 		Constructed:  Table1.Column1.Asc(),
-		ExpectedStmt: "table1.column1 ASC",
+		ExpectedStmt: `"table1".column1 ASC`,
 	},
 	{
 		Constructed:  Table1.Column1.Desc(),
-		ExpectedStmt: "table1.column1 DESC",
+		ExpectedStmt: `"table1".column1 DESC`,
 	},
 	{
 		Constructed:  Table1.Column1.IsNull(),
-		ExpectedStmt: "table1.column1 IS NULL",
+		ExpectedStmt: `"table1".column1 IS NULL`,
 	},
 	{
 		Constructed:  Table1.Column1.IsNotNull(),
-		ExpectedStmt: "table1.column1 IS NOT NULL",
+		ExpectedStmt: `"table1".column1 IS NOT NULL`,
 	},
 	{
 		Constructed:  Table1.Column1.Eq(Table2.Column1).Or(Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: "(table1.column1 = table2.column1 OR table1.column2 = table2.column2)",
+		ExpectedStmt: `("table1".column1 = "table2".column1 OR "table1".column2 = "table2".column2)`,
 	},
 	{
 		Constructed:  Table1.Column1.Eq(Table2.Column1).And(Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: "(table1.column1 = table2.column1 AND table1.column2 = table2.column2)",
+		ExpectedStmt: `("table1".column1 = "table2".column1 AND "table1".column2 = "table2".column2)`,
 	},
 	{
 		Constructed:  Table1.Column1.Eq(Table2.Column1).And(Table1.Column2.Eq(Table2.Column2)).And(Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: "((table1.column1 = table2.column1 AND table1.column2 = table2.column2) AND table1.column2 = table2.column2)",
+		ExpectedStmt: `(("table1".column1 = "table2".column1 AND "table1".column2 = "table2".column2) AND "table1".column2 = "table2".column2)`,
 	},
 	{
 		Constructed:  Table1.Column1.Eq(Table2.Column1).And(Table1.Column2.Eq(Table2.Column2)).Or(Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: "((table1.column1 = table2.column1 AND table1.column2 = table2.column2) OR table1.column2 = table2.column2)",
+		ExpectedStmt: `(("table1".column1 = "table2".column1 AND "table1".column2 = "table2".column2) OR "table1".column2 = "table2".column2)`,
 	},
 	{
 		Constructed:  Table1.BoolColumn.IsEq(true),
-		ExpectedStmt: "table1.bool_column = $1",
+		ExpectedStmt: `"table1".bool_column = $1`,
 	},
 	{
 		Constructed:  Table1.BoolColumn.IsNotEq(true),
-		ExpectedStmt: "table1.bool_column != $1",
+		ExpectedStmt: `"table1".bool_column != $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.IsGt(1.0),
-		ExpectedStmt: "table1.decimal_column > $1",
+		ExpectedStmt: `"table1".decimal_column > $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.IsGte(1.0),
-		ExpectedStmt: "table1.decimal_column >= $1",
+		ExpectedStmt: `"table1".decimal_column >= $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.IsLt(1.0),
-		ExpectedStmt: "table1.decimal_column < $1",
+		ExpectedStmt: `"table1".decimal_column < $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.IsLte(1.0),
-		ExpectedStmt: "table1.decimal_column <= $1",
+		ExpectedStmt: `"table1".decimal_column <= $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.IsEq(1.0),
-		ExpectedStmt: "table1.decimal_column = $1",
+		ExpectedStmt: `"table1".decimal_column = $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.IsNotEq(1.0),
-		ExpectedStmt: "table1.decimal_column != $1",
+		ExpectedStmt: `"table1".decimal_column != $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.Add(Int64(42)),
-		ExpectedStmt: "table1.decimal_column + $1",
+		ExpectedStmt: `"table1".decimal_column + $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.Sub(Int64(-42)),
-		ExpectedStmt: "table1.decimal_column - $1",
+		ExpectedStmt: `"table1".decimal_column - $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.Mult(Int64(42)),
-		ExpectedStmt: "table1.decimal_column * $1",
+		ExpectedStmt: `"table1".decimal_column * $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.Div(Int64(0)),
-		ExpectedStmt: "table1.decimal_column / $1",
+		ExpectedStmt: `"table1".decimal_column / $1`,
 	},
 	{
 		Constructed:  Table1.DecimalColumn.Sqrt(),
-		ExpectedStmt: "|/ table1.decimal_column",
+		ExpectedStmt: `|/ "table1".decimal_column`,
 	},
 	{
 		Constructed:  Table1.StringColumn.IsEq("foo"),
-		ExpectedStmt: "table1.string_column = $1",
+		ExpectedStmt: `"table1".string_column = $1`,
 	},
 	{
 		Constructed:  Table1.StringColumn.IsNotEq("foo"),
-		ExpectedStmt: "table1.string_column != $1",
+		ExpectedStmt: `"table1".string_column != $1`,
 	},
 	{
 		Constructed:  Table1.TimeColumn.IsGt(time.Now()),
-		ExpectedStmt: "table1.time_column > $1",
+		ExpectedStmt: `"table1".time_column > $1`,
 	},
 	{
 		Constructed:  Table1.TimeColumn.IsGte(time.Now()),
-		ExpectedStmt: "table1.time_column >= $1",
+		ExpectedStmt: `"table1".time_column >= $1`,
 	},
 	{
 		Constructed:  Table1.TimeColumn.IsLt(time.Now()),
-		ExpectedStmt: "table1.time_column < $1",
+		ExpectedStmt: `"table1".time_column < $1`,
 	},
 	{
 		Constructed:  Table1.TimeColumn.IsLte(time.Now()),
-		ExpectedStmt: "table1.time_column <= $1",
+		ExpectedStmt: `"table1".time_column <= $1`,
 	},
 	{
 		Constructed:  Table1.TimeColumn.IsEq(time.Now()),
-		ExpectedStmt: "table1.time_column = $1",
+		ExpectedStmt: `"table1".time_column = $1`,
 	},
 	{
 		Constructed:  Table1.TimeColumn.IsNotEq(time.Now()),
-		ExpectedStmt: "table1.time_column != $1",
+		ExpectedStmt: `"table1".time_column != $1`,
 	},
 	{
 		Constructed:  Table1.ID.IsEq(uuid.Nil),
-		ExpectedStmt: "table1.id = $1",
+		ExpectedStmt: `"table1".id = $1`,
 	},
 	{
 		Constructed:  Table1.ID.IsNotEq(uuid.Nil),
-		ExpectedStmt: "table1.id != $1",
+		ExpectedStmt: `"table1".id != $1`,
 	},
 	{
 		Constructed:  Table1.ID.In(Select().From(Table1)),
-		ExpectedStmt: "table1.id IN (SELECT * FROM public.table1)",
+		ExpectedStmt: `"table1".id IN (SELECT * FROM public.table1)`,
 	},
 	{
 		Constructed:  Table1.ID.NotIn(Select().From(Table1)),
-		ExpectedStmt: "table1.id NOT IN (SELECT * FROM public.table1)",
+		ExpectedStmt: `"table1".id NOT IN (SELECT * FROM public.table1)`,
 	},
 	{
 		Constructed:  Table1.ID.IsIn(uuid.Nil, uuid.Nil),
-		ExpectedStmt: "table1.id IN ($1, $2)",
+		ExpectedStmt: `"table1".id IN ($1, $2)`,
 		Arguments:    []interface{}{uuid.Nil, uuid.Nil},
 	},
 	{
 		Constructed:  Table1.ID.IsNotIn(uuid.Nil, uuid.Nil),
-		ExpectedStmt: "table1.id NOT IN ($1, $2)",
+		ExpectedStmt: `"table1".id NOT IN ($1, $2)`,
 		Arguments:    []interface{}{uuid.Nil, uuid.Nil},
 	},
 }

--- a/pkg/gooq/field.go
+++ b/pkg/gooq/field.go
@@ -38,7 +38,7 @@ func (field *fieldImpl) GetQualifiedName() string {
 	if selectableName == "" {
 		return field.name
 	} else {
-		return fmt.Sprintf("%s.%s", selectableName, field.name)
+		return fmt.Sprintf("\"%s\".%s", selectableName, field.name)
 	}
 }
 

--- a/pkg/gooq/function_test.go
+++ b/pkg/gooq/function_test.go
@@ -5,167 +5,167 @@ import "testing"
 var functionTestCases = []TestCase{
 	{
 		Constructed:  And(Table1.Column1.Eq(Table2.Column1), Table1.Column2.Eq(Table2.Column2), Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: "(table1.column1 = table2.column1 AND table1.column2 = table2.column2 AND table1.column2 = table2.column2)",
+		ExpectedStmt: `("table1".column1 = "table2".column1 AND "table1".column2 = "table2".column2 AND "table1".column2 = "table2".column2)`,
 	},
 	{
 		Constructed:  Or(Table1.Column1.Eq(Table2.Column1), Table1.Column2.Eq(Table2.Column2), Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: "(table1.column1 = table2.column1 OR table1.column2 = table2.column2 OR table1.column2 = table2.column2)",
+		ExpectedStmt: `("table1".column1 = "table2".column1 OR "table1".column2 = "table2".column2 OR "table1".column2 = "table2".column2)`,
 	},
 	{
 		Constructed:  Select(Coalesce(Table1.Column1, Table1.Column2)).From(Table1),
-		ExpectedStmt: "SELECT COALESCE(table1.column1, table1.column2) FROM public.table1",
+		ExpectedStmt: `SELECT COALESCE("table1".column1, "table1".column2) FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Coalesce(Table1.Column1, Int64(0))).From(Table1),
-		ExpectedStmt: "SELECT COALESCE(table1.column1, $1) FROM public.table1",
+		ExpectedStmt: `SELECT COALESCE("table1".column1, $1) FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Count(Asterisk)).From(Table1),
-		ExpectedStmt: "SELECT COUNT(*) FROM public.table1",
+		ExpectedStmt: `SELECT COUNT(*) FROM public.table1`,
 	},
 	{
 		Constructed:  Greatest(Int64(10), Int64(2), Int64(23)),
-		ExpectedStmt: "GREATEST($1, $2, $3)",
+		ExpectedStmt: `GREATEST($1, $2, $3)`,
 	},
 	{
 		Constructed:  Least(String("a"), String("b")),
-		ExpectedStmt: "LEAST($1, $2)",
+		ExpectedStmt: `LEAST($1, $2)`,
 	},
 	{
 		Constructed:  Ascii(String("abc")),
-		ExpectedStmt: "ASCII($1)",
+		ExpectedStmt: `ASCII($1)`,
 	},
 	{
 		Constructed:  Ascii(Table1.Column1),
-		ExpectedStmt: "ASCII(table1.column1)",
+		ExpectedStmt: `ASCII("table1".column1)`,
 	},
 	{
 		Constructed:  BTrim(String("    abc    ")),
-		ExpectedStmt: "BTRIM($1)",
+		ExpectedStmt: `BTRIM($1)`,
 	},
 	{
 		Constructed:  LTrim(Table1.Column1, String("xyz")),
-		ExpectedStmt: "LTRIM(table1.column1, $1)",
+		ExpectedStmt: `LTRIM("table1".column1, $1)`,
 	},
 	{
 		Constructed:  RTrim(String("xyzxyzabcxyz"), Table1.Column1),
-		ExpectedStmt: "RTRIM($1, table1.column1)",
+		ExpectedStmt: `RTRIM($1, "table1".column1)`,
 	},
 	{
 		Constructed:  Chr(Table1.Column3),
-		ExpectedStmt: "CHR(table1.column3)",
+		ExpectedStmt: `CHR("table1".column3)`,
 	},
 	{
 		Constructed:  Concat(String("xyzxyzabcxyz"), Table1.Column3, Int64(3)),
-		ExpectedStmt: "CONCAT($1, table1.column3, $2)",
+		ExpectedStmt: `CONCAT($1, "table1".column3, $2)`,
 	},
 	{
 		Constructed:  ConcatWs(String("x"), Table1.Column3, Int64(3), String("four")),
-		ExpectedStmt: "CONCAT_WS($1, table1.column3, $2, $3)",
+		ExpectedStmt: `CONCAT_WS($1, "table1".column3, $2, $3)`,
 	},
 	{
 		Constructed:  Format(String("Hello %s, %1$s"), Table1.Column3),
-		ExpectedStmt: "FORMAT($1, table1.column3)",
+		ExpectedStmt: `FORMAT($1, "table1".column3)`,
 	},
 	{
 		Constructed:  Format(String("no formatting to be done")),
-		ExpectedStmt: "FORMAT($1)",
+		ExpectedStmt: `FORMAT($1)`,
 	},
 	{
 		Constructed:  InitCap(String("initCap THIS SenTEnce")),
-		ExpectedStmt: "INITCAP($1)",
+		ExpectedStmt: `INITCAP($1)`,
 	},
 	{
 		Constructed:  Left(Table1.Column1, Int64(3)),
-		ExpectedStmt: "LEFT(table1.column1, $1)",
+		ExpectedStmt: `LEFT("table1".column1, $1)`,
 	},
 	{
 		Constructed:  Right(String("take my right chars"), Table1.Column3),
-		ExpectedStmt: "RIGHT($1, table1.column3)",
+		ExpectedStmt: `RIGHT($1, "table1".column3)`,
 	},
 	{
 		Constructed:  Length(Table1.Column1),
-		ExpectedStmt: "LENGTH(table1.column1)",
+		ExpectedStmt: `LENGTH("table1".column1)`,
 	},
 	{
 		Constructed:  Length(String("jose"), String("UTF8")),
-		ExpectedStmt: "LENGTH($1, $2)",
+		ExpectedStmt: `LENGTH($1, $2)`,
 	},
 	{
 		Constructed:  LPad(String("hi"), Int64(7)),
-		ExpectedStmt: "LPAD($1, $2)",
+		ExpectedStmt: `LPAD($1, $2)`,
 	},
 	{
 		Constructed:  RPad(Table1.Column2, Table1.Column3, Table1.Column1),
-		ExpectedStmt: "RPAD(table1.column2, table1.column3, table1.column1)",
+		ExpectedStmt: `RPAD("table1".column2, "table1".column3, "table1".column1)`,
 	},
 	{
 		Constructed:  Md5(Table1.Column2),
-		ExpectedStmt: "MD5(table1.column2)",
+		ExpectedStmt: `MD5("table1".column2)`,
 	},
 	{
 		Constructed:  PgClientEncoding(),
-		ExpectedStmt: "PG_CLIENT_ENCODING()",
+		ExpectedStmt: `PG_CLIENT_ENCODING()`,
 	},
 	{
 		Constructed:  QuoteIdent(String("foo bar")),
-		ExpectedStmt: "QUOTE_IDENT($1)",
+		ExpectedStmt: `QUOTE_IDENT($1)`,
 	},
 	{
 		Constructed:  QuoteLiteral(String("foo bar")),
-		ExpectedStmt: "QUOTE_LITERAL($1)",
+		ExpectedStmt: `QUOTE_LITERAL($1)`,
 	},
 	{
 		Constructed:  QuoteLiteral(Float64(42.5)),
-		ExpectedStmt: "QUOTE_LITERAL($1)",
+		ExpectedStmt: `QUOTE_LITERAL($1)`,
 	},
 	{
 		Constructed:  QuoteNullable(Table3.ID),
-		ExpectedStmt: "QUOTE_NULLABLE(table3.id)",
+		ExpectedStmt: `QUOTE_NULLABLE("table3".id)`,
 	},
 	{
 		Constructed:  Repeat(String("abc"), Table1.Column3),
-		ExpectedStmt: "REPEAT($1, table1.column3)",
+		ExpectedStmt: `REPEAT($1, "table1".column3)`,
 	},
 	{
 		Constructed:  Replace(Table1.Column1, String("ab"), String("CD")),
-		ExpectedStmt: "REPLACE(table1.column1, $1, $2)",
+		ExpectedStmt: `REPLACE("table1".column1, $1, $2)`,
 	},
 	{
 		Constructed:  Reverse(String("reversable")),
-		ExpectedStmt: "REVERSE($1)",
+		ExpectedStmt: `REVERSE($1)`,
 	},
 	{
 		Constructed:  SplitPart(String("abc~@~def~@~ghi"), String("~@~"), Int64(2)),
-		ExpectedStmt: "SPLIT_PART($1, $2, $3)",
+		ExpectedStmt: `SPLIT_PART($1, $2, $3)`,
 	},
 	{
 		Constructed:  Strpos(Table1.Column1, String("ab")),
-		ExpectedStmt: "STRPOS(table1.column1, $1)",
+		ExpectedStmt: `STRPOS("table1".column1, $1)`,
 	},
 	{
 		Constructed:  Substr(Table1.Column1, Int64(2), Int64(5)),
-		ExpectedStmt: "SUBSTR(table1.column1, $1, $2)",
+		ExpectedStmt: `SUBSTR("table1".column1, $1, $2)`,
 	},
 	{
 		Constructed:  StartsWith(String("alphabet"), String("alph")),
-		ExpectedStmt: "STARTS_WITH($1, $2)",
+		ExpectedStmt: `STARTS_WITH($1, $2)`,
 	},
 	{
 		Constructed:  ToAscii(Table1.Column1),
-		ExpectedStmt: "TO_ASCII(table1.column1)",
+		ExpectedStmt: `TO_ASCII("table1".column1)`,
 	},
 	{
 		Constructed:  ToAscii(String("Karel"), String("WIN1250")),
-		ExpectedStmt: "TO_ASCII($1, $2)",
+		ExpectedStmt: `TO_ASCII($1, $2)`,
 	},
 	{
 		Constructed:  ToHex(Table1.Column3),
-		ExpectedStmt: "TO_HEX(table1.column3)",
+		ExpectedStmt: `TO_HEX("table1".column3)`,
 	},
 	{
 		Constructed:  Translate(String("12345"), String("143"), String("ax")),
-		ExpectedStmt: "TRANSLATE($1, $2, $3)",
+		ExpectedStmt: `TRANSLATE($1, $2, $3)`,
 	},
 }
 

--- a/pkg/gooq/insert_test.go
+++ b/pkg/gooq/insert_test.go
@@ -5,50 +5,50 @@ import "testing"
 var insertTestCases = []TestCase{
 	{
 		Constructed:  InsertInto(Table1).Set(Table1.Column1, "foo"),
-		ExpectedStmt: "INSERT INTO public.table1 (column1) VALUES ($1)",
+		ExpectedStmt: `INSERT INTO public.table1 (column1) VALUES ($1)`,
 	},
 	{
 		Constructed:  InsertInto(Table1).Set(Table1.Column1, "foo").Set(Table1.Column2, "bar"),
-		ExpectedStmt: "INSERT INTO public.table1 (column1, column2) VALUES ($1, $2)",
+		ExpectedStmt: `INSERT INTO public.table1 (column1, column2) VALUES ($1, $2)`,
 	},
 	{
 		Constructed: InsertInto(Table1).
 			Values("1", "2", 3, 4).
 			Values("2", "3", 4, 5),
-		ExpectedStmt: "INSERT INTO public.table1 VALUES ($1, $2, $3, $4) ($5, $6, $7, $8)",
+		ExpectedStmt: `INSERT INTO public.table1 VALUES ($1, $2, $3, $4) ($5, $6, $7, $8)`,
 	},
 	{
 		Constructed: InsertInto(Table1).
 			Columns(Table1.Column1, Table1.Column2, Table1.Column3, Table1.Column4).
 			Values("1", "2", 3, 4).
 			Values("2", "3", 4, 5),
-		ExpectedStmt: "INSERT INTO public.table1 (column1, column2, column3, column4) VALUES ($1, $2, $3, $4) ($5, $6, $7, $8)",
+		ExpectedStmt: `INSERT INTO public.table1 (column1, column2, column3, column4) VALUES ($1, $2, $3, $4) ($5, $6, $7, $8)`,
 	},
 	{
 		Constructed:  InsertInto(Table1).Select(Select(Table1.Column1).From(Table1)),
-		ExpectedStmt: "INSERT INTO public.table1 (SELECT table1.column1 FROM public.table1)",
+		ExpectedStmt: `INSERT INTO public.table1 (SELECT "table1".column1 FROM public.table1)`,
 	},
 	{
 		Constructed:  InsertInto(Table1).Set(Table1.Column1, "foo").OnConflictDoNothing(),
-		ExpectedStmt: "INSERT INTO public.table1 (column1) VALUES ($1) ON CONFLICT DO NOTHING",
+		ExpectedStmt: `INSERT INTO public.table1 (column1) VALUES ($1) ON CONFLICT DO NOTHING`,
 	},
 	{
 		Constructed:  InsertInto(Table1).Set(Table1.Column1, "foo").Returning(Table1.Column1),
-		ExpectedStmt: "INSERT INTO public.table1 (column1) VALUES ($1) RETURNING table1.column1",
+		ExpectedStmt: `INSERT INTO public.table1 (column1) VALUES ($1) RETURNING "table1".column1`,
 	},
 	{
 		Constructed: InsertInto(Table1).
 			Set(Table1.Column1, "foo").Set(Table1.Column2, "bar").
 			OnConflictDoUpdate(&Table1Constraint).
 			SetUpdates(Table1.Column2, String("bar")),
-		ExpectedStmt: "INSERT INTO public.table1 (column1, column2) VALUES ($1, $2) ON CONFLICT DO UPDATE (table1.column1) SET column2 = $3",
+		ExpectedStmt: `INSERT INTO public.table1 (column1, column2) VALUES ($1, $2) ON CONFLICT DO UPDATE ("table1".column1) SET column2 = $3`,
 	},
 	{
 		Constructed: InsertInto(Table1).
 			Set(Table1.Column1, "foo").Set(Table1.Column2, "bar").
 			OnConflictDoUpdate(&Table1Constraint).
 			SetUpdateColumns(Table1.Column2),
-		ExpectedStmt: "INSERT INTO public.table1 (column1, column2) VALUES ($1, $2) ON CONFLICT DO UPDATE (table1.column1) SET column2 = EXCLUDED.column2",
+		ExpectedStmt: `INSERT INTO public.table1 (column1, column2) VALUES ($1, $2) ON CONFLICT DO UPDATE ("table1".column1) SET column2 = "EXCLUDED".column2`,
 	},
 }
 

--- a/pkg/gooq/select_test.go
+++ b/pkg/gooq/select_test.go
@@ -24,57 +24,57 @@ var selectTestCases = []TestCase{
 	},
 	{
 		Constructed:  Select(Table1.Column1).From(Table1),
-		ExpectedStmt: `SELECT table1.column1 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column1 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column1, Table1.Column2).From(Table1),
-		ExpectedStmt: `SELECT table1.column1, table1.column2 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column1, "table1".column2 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column1.As("result")).From(Table1),
-		ExpectedStmt: `SELECT table1.column1 AS "result" FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column1 AS "result" FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column1).From(Table1).Where(Table1.Column2.Eq(String("foo"))),
-		ExpectedStmt: `SELECT table1.column1 FROM public.table1 WHERE table1.column2 = $1`,
+		ExpectedStmt: `SELECT "table1".column1 FROM public.table1 WHERE "table1".column2 = $1`,
 	},
 	{
 		Constructed:  Select(Table1.Column1.Filter(Table1.Column2.Eq(String("foo")))).From(Table1),
-		ExpectedStmt: `SELECT table1.column1 FILTER (WHERE table1.column2 = $1) FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column1 FILTER (WHERE "table1".column2 = $1) FROM public.table1`,
 	},
 	{
 		Constructed: Select(Table1.Column1).From(Table1).Where(
 			Table1.Column2.IsIn("quix", "foo"),
 			Table1.Column2.Eq(String("quack"))),
-		ExpectedStmt: `SELECT table1.column1 FROM public.table1 WHERE table1.column2 IN ($1, $2) AND table1.column2 = $3`,
+		ExpectedStmt: `SELECT "table1".column1 FROM public.table1 WHERE "table1".column2 IN ($1, $2) AND "table1".column2 = $3`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Add(Int64(5))).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 + $1 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 + $1 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Add(Float64(1.72))).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 + $1 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 + $1 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Add(Table1.Column4)).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 + table1.column4 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 + "table1".column4 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Sub(Table1.Column4)).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 - table1.column4 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 - "table1".column4 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Mult(Table1.Column4)).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 * table1.column4 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 * "table1".column4 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Div(Table1.Column4)).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 / table1.column4 FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 / "table1".column4 FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Table1.Column3.Div(Table1.Column4).As("result")).From(Table1),
-		ExpectedStmt: `SELECT table1.column3 / table1.column4 AS "result" FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column3 / "table1".column4 AS "result" FROM public.table1`,
 	},
 	{
 		Constructed: Select(Table1.Column1).From(Table1).Where(
@@ -85,52 +85,52 @@ var selectTestCases = []TestCase{
 					Table1.Column2.Eq(String("foo")),
 					Table1.Column2.Eq(String("quack")))).
 			OrderBy(NewStringField(NewTable("", ""), "column2").Asc()),
-		ExpectedStmt: `SELECT table1.column1 FROM public.table1 WHERE table1.column2 = $1 AND table1.column2 = $2 UNION (SELECT table1.column1 FROM public.table1 WHERE table1.column2 = $3 AND table1.column2 = $4) ORDER BY column2 ASC`,
+		ExpectedStmt: `SELECT "table1".column1 FROM public.table1 WHERE "table1".column2 = $1 AND "table1".column2 = $2 UNION (SELECT "table1".column1 FROM public.table1 WHERE "table1".column2 = $3 AND "table1".column2 = $4) ORDER BY column2 ASC`,
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1.Asc()),
-		ExpectedStmt: `SELECT * FROM public.table1 ORDER BY table1.column1 ASC`,
+		ExpectedStmt: `SELECT * FROM public.table1 ORDER BY "table1".column1 ASC`,
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1.Desc()),
-		ExpectedStmt: `SELECT * FROM public.table1 ORDER BY table1.column1 DESC`,
+		ExpectedStmt: `SELECT * FROM public.table1 ORDER BY "table1".column1 DESC`,
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1, Table1.ID).Seek("foo", "bar"),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE ((table1.column1 > $1) OR (table1.column1 = $2 AND table1.id > $3)) ORDER BY table1.column1, table1.id`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE (("table1".column1 > $1) OR ("table1".column1 = $2 AND "table1".id > $3)) ORDER BY "table1".column1, "table1".id`,
 		Arguments:    []interface{}{"foo", "foo", "bar"},
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1.Desc(), Table1.ID.Desc()).Seek("foo", "bar"),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE ((table1.column1 < $1) OR (table1.column1 = $2 AND table1.id < $3)) ORDER BY table1.column1 DESC, table1.id DESC`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE (("table1".column1 < $1) OR ("table1".column1 = $2 AND "table1".id < $3)) ORDER BY "table1".column1 DESC, "table1".id DESC`,
 		Arguments:    []interface{}{"foo", "foo", "bar"},
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1.Asc(), Table1.ID.Desc()).Seek("foo", "bar"),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE ((table1.column1 > $1) OR (table1.column1 = $2 AND table1.id < $3)) ORDER BY table1.column1 ASC, table1.id DESC`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE (("table1".column1 > $1) OR ("table1".column1 = $2 AND "table1".id < $3)) ORDER BY "table1".column1 ASC, "table1".id DESC`,
 		Arguments:    []interface{}{"foo", "foo", "bar"},
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1.Desc(), Table1.ID.Asc()).Seek("foo", "bar"),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE ((table1.column1 < $1) OR (table1.column1 = $2 AND table1.id > $3)) ORDER BY table1.column1 DESC, table1.id ASC`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE (("table1".column1 < $1) OR ("table1".column1 = $2 AND "table1".id > $3)) ORDER BY "table1".column1 DESC, "table1".id ASC`,
 		Arguments:    []interface{}{"foo", "foo", "bar"},
 	},
 	{
 		Constructed:  Select().From(Table1).OrderBy(Table1.Column1.Desc(), Table1.Column2.Desc(), Table1.ID.Asc()).Seek("foo", "bar", "baz"),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE ((table1.column1 < $1) OR (table1.column1 = $2 AND table1.column2 < $3) OR (table1.column1 = $4 AND table1.column2 = $5 AND table1.id > $6)) ORDER BY table1.column1 DESC, table1.column2 DESC, table1.id ASC`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE (("table1".column1 < $1) OR ("table1".column1 = $2 AND "table1".column2 < $3) OR ("table1".column1 = $4 AND "table1".column2 = $5 AND "table1".id > $6)) ORDER BY "table1".column1 DESC, "table1".column2 DESC, "table1".id ASC`,
 		Arguments:    []interface{}{"foo", "foo", "bar", "foo", "bar", "baz"},
 	},
 	{
 		Constructed:  Select().From(Table1).GroupBy(Table1.Column1),
-		ExpectedStmt: `SELECT * FROM public.table1 GROUP BY table1.column1`,
+		ExpectedStmt: `SELECT * FROM public.table1 GROUP BY "table1".column1`,
 	},
 	{
 		Constructed:  Select(Table1.Column1.Filter(Table1.Column2.Eq(String("foo")))).From(Table1),
-		ExpectedStmt: `SELECT table1.column1 FILTER (WHERE table1.column2 = $1) FROM public.table1`,
+		ExpectedStmt: `SELECT "table1".column1 FILTER (WHERE "table1".column2 = $1) FROM public.table1`,
 	},
 	{
 		Constructed:  Select(Coalesce(Table1.Column1.Filter(Table1.Column2.Eq(String("foo"))), Int64(0)).As("total")).From(Table1),
-		ExpectedStmt: `SELECT COALESCE(table1.column1 FILTER (WHERE table1.column2 = $1), $2) AS "total" FROM public.table1`,
+		ExpectedStmt: `SELECT COALESCE("table1".column1 FILTER (WHERE "table1".column2 = $1), $2) AS "total" FROM public.table1`,
 	},
 	{
 		Constructed:  Select().From(Table1).Limit(10),
@@ -138,65 +138,65 @@ var selectTestCases = []TestCase{
 	},
 	{
 		Constructed:  Select(Table1.Column1).From(Table1).Join(Table2).On(Table2.Column1.Eq(Table1.Column1)),
-		ExpectedStmt: `SELECT table1.column1 FROM public.table1 JOIN public.table2 ON table2.column1 = table1.column1`,
+		ExpectedStmt: `SELECT "table1".column1 FROM public.table1 JOIN public.table2 ON "table2".column1 = "table1".column1`,
 	},
 	{
 		Constructed: Select(Table1.Column1, Table2.Column1).From(Table1).
 			Join(Table2).On(Table2.Column1.Eq(Table1.Column1), Table2.Column2.Eq(Table1.Column2)),
-		ExpectedStmt: `SELECT table1.column1, table2.column1 FROM public.table1 JOIN public.table2 ON table2.column1 = table1.column1 AND table2.column2 = table1.column2`,
+		ExpectedStmt: `SELECT "table1".column1, "table2".column1 FROM public.table1 JOIN public.table2 ON "table2".column1 = "table1".column1 AND "table2".column2 = "table1".column2`,
 	},
 	{
 		Constructed: Select(Table1.Column1).From(Table1).
 			LeftOuterJoin(Table2).On(Table2.Column1.Eq(Table1.Column1)).
 			LeftOuterJoin(Table3).On(Table3.Column1.Eq(Table1.Column1)),
-		ExpectedStmt: `SELECT table1.column1 FROM public.table1 LEFT OUTER JOIN public.table2 ON table2.column1 = table1.column1 LEFT OUTER JOIN public.table3 ON table3.column1 = table1.column1`,
+		ExpectedStmt: `SELECT "table1".column1 FROM public.table1 LEFT OUTER JOIN public.table2 ON "table2".column1 = "table1".column1 LEFT OUTER JOIN public.table3 ON "table3".column1 = "table1".column1`,
 	},
 	{
 		Constructed: Select().From(Table1).
 			LeftOuterJoin(Select(Table1.Column1).From(Table1).As("boo")).
 			On(NewStringField(NewTable("", "boo"), "column1").Eq(Table1.Column1)),
-		ExpectedStmt: `SELECT * FROM public.table1 LEFT OUTER JOIN (SELECT table1.column1 FROM public.table1) AS "boo" ON boo.column1 = table1.column1`,
+		ExpectedStmt: `SELECT * FROM public.table1 LEFT OUTER JOIN (SELECT "table1".column1 FROM public.table1) AS "boo" ON "boo".column1 = "table1".column1`,
 	},
 	{
 		Constructed:  Select().From(Select(Table1.Column1).From(Table1).As("boo")),
-		ExpectedStmt: `SELECT * FROM (SELECT table1.column1 FROM public.table1) AS "boo"`,
+		ExpectedStmt: `SELECT * FROM (SELECT "table1".column1 FROM public.table1) AS "boo"`,
 	},
 	{
 		Constructed: Select(Table1.Column1, Table2.Column1).From(
 			Select(Table1.Column1).From(Table1).As("boo")).
 			Join(Table2).On(Table2.Column1.Eq(Table1.Column1)),
-		ExpectedStmt: `SELECT table1.column1, table2.column1 FROM (SELECT table1.column1 FROM public.table1) AS "boo" JOIN public.table2 ON table2.column1 = table1.column1`,
+		ExpectedStmt: `SELECT "table1".column1, "table2".column1 FROM (SELECT "table1".column1 FROM public.table1) AS "boo" JOIN public.table2 ON "table2".column1 = "table1".column1`,
 	},
 	{
 		Constructed:  Select().From(Table1).GroupBy(Table1.Column1).Having(Count(Asterisk).IsGt(5)),
-		ExpectedStmt: `SELECT * FROM public.table1 GROUP BY table1.column1 HAVING COUNT(*) > $1`,
+		ExpectedStmt: `SELECT * FROM public.table1 GROUP BY "table1".column1 HAVING COUNT(*) > $1`,
 		Arguments:    []interface{}{float64(5)},
 	},
 	{
 		Constructed: Select().From(Table1).
 			Where(Table1.Column1.IsEq("foo")).
 			For(LockingTypeUpdate, LockingOptionNone),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE table1.column1 = $1 FOR UPDATE`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE "table1".column1 = $1 FOR UPDATE`,
 		Arguments:    []interface{}{"foo"},
 	},
 	{
 		Constructed: Select().From(Table1).
 			Where(Table1.Column1.IsEq("foo")).
 			For(LockingTypeUpdate, LockingOptionSkipLocked),
-		ExpectedStmt: `SELECT * FROM public.table1 WHERE table1.column1 = $1 FOR UPDATE SKIP LOCKED`,
+		ExpectedStmt: `SELECT * FROM public.table1 WHERE "table1".column1 = $1 FOR UPDATE SKIP LOCKED`,
 		Arguments:    []interface{}{"foo"},
 	},
 	//{
 	//	Select(TimeBucket5MinutesField, Table1.Column2.Avg()).From(Table1),
-	//	"SELECT time_bucket('5 minutes', table1.creation_date) AS five_min, AVG(table1.column2) FROM public.table1",
+	//	"SELECT time_bucket('5 minutes', "table1".creation_date) AS five_min, AVG("table1".column2) FROM public.table1",
 	//},
 	//{
 	//	Select(TimeBucket("5 minutes", Table1.CreationDate), Table1.Column1.Last(Table1.CreationDate.GetName()).As("last"), Table1.Column1.First(Table1.CreationDate.GetName()).As("first")).From(Table1),
-	//	"SELECT time_bucket('5 minutes', table1.creation_date), last(table1.column1, creation_date) AS last, first(table1.column1, creation_date) AS first FROM public.table1",
+	//	"SELECT time_bucket('5 minutes', "table1".creation_date), last("table1".column1, creation_date) AS last, first("table1".column1, creation_date) AS first FROM public.table1",
 	//},
 	//{
 	//	Select(TimeBucket5MinutesField, Table1.Column2.Avg()).From(Table1).GroupBy(TimeBucket5MinutesField),
-	//	"SELECT time_bucket('5 minutes', table1.creation_date) AS five_min, AVG(table1.column2) FROM public.table1 GROUP BY five_min",
+	//	"SELECT time_bucket('5 minutes', "table1".creation_date) AS five_min, AVG("table1".column2) FROM public.table1 GROUP BY five_min",
 	//},
 }
 

--- a/pkg/gooq/update_test.go
+++ b/pkg/gooq/update_test.go
@@ -9,7 +9,7 @@ var updateTestCases = []TestCase{
 	},
 	{
 		Constructed:  Update(Table1).Set(Table1.Column3, Table1.Column4.Add(Int64(10))),
-		ExpectedStmt: `UPDATE public.table1 SET column3 = table1.column4 + $1`,
+		ExpectedStmt: `UPDATE public.table1 SET column3 = "table1".column4 + $1`,
 	},
 	{
 		Constructed:  Update(Table1).Set(Table1.Column3, Select().From(Table2)),
@@ -17,17 +17,17 @@ var updateTestCases = []TestCase{
 	},
 	{
 		Constructed:  Update(Table1).Set(Table1.Column1, "10").Where(Table1.Column2.Eq(String("foo"))),
-		ExpectedStmt: `UPDATE public.table1 SET column1 = $1 WHERE table1.column2 = $2`,
+		ExpectedStmt: `UPDATE public.table1 SET column1 = $1 WHERE "table1".column2 = $2`,
 	},
 	{
 		Constructed: Update(Table1).Set(Table1.Column1, Table2.Column1).
 			From(Table2).Where(Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: `UPDATE public.table1 SET column1 = table2.column1 FROM public.table2 WHERE table1.column2 = table2.column2`,
+		ExpectedStmt: `UPDATE public.table1 SET column1 = "table2".column1 FROM public.table2 WHERE "table1".column2 = "table2".column2`,
 	},
 	{
 		Constructed: Update(Table1).Set(Table1.Column1, Table2.Column1).
 			From(Select().From(Table2).As("foo")).Where(Table1.Column2.Eq(Table2.Column2)),
-		ExpectedStmt: `UPDATE public.table1 SET column1 = table2.column1 FROM (SELECT * FROM public.table2) AS "foo" WHERE table1.column2 = table2.column2`,
+		ExpectedStmt: `UPDATE public.table1 SET column1 = "table2".column1 FROM (SELECT * FROM public.table2) AS "foo" WHERE "table1".column2 = "table2".column2`,
 	},
 	{
 		Constructed:  Update(Table1).Set(Table1.Column1, "10").OnConflictDoNothing(),
@@ -35,7 +35,7 @@ var updateTestCases = []TestCase{
 	},
 	{
 		Constructed:  Update(Table1).Set(Table1.Column1, "10").Returning(Table1.Column1),
-		ExpectedStmt: `UPDATE public.table1 SET column1 = $1 RETURNING table1.column1`,
+		ExpectedStmt: `UPDATE public.table1 SET column1 = $1 RETURNING "table1".column1`,
 	},
 }
 


### PR DESCRIPTION
When rendering a field, output `"table1".column1` instead of `table1.column1`.