### PR TITLE
Add nullable package to gOOQ

### DIFF
--- a/examples/swapi/migrations/001_init.up.sql
+++ b/examples/swapi/migrations/001_init.up.sql
@@ -30,6 +30,12 @@ CREATE TABLE species(
   FOREIGN KEY (eye_color) REFERENCES color_reference_table(value)
 );
 
+CREATE TABLE weapon(
+  id uuid primary key NOT NULL,
+  damage int NOT NULL,
+  price int NOT NULL
+);
+
 CREATE TABLE person(
   id uuid primary key NOT NULL,
   name text NOT NULL,
@@ -42,11 +48,14 @@ CREATE TABLE person(
   gender gender NOT NULL,
   home_world text NOT NULL,
   species_id uuid NOT NULL,
+  weapon_id uuid,
   FOREIGN KEY (hair_color) REFERENCES color_reference_table(value),
   FOREIGN KEY (skin_color) REFERENCES color_reference_table(value),
   FOREIGN KEY (eye_color) REFERENCES color_reference_table(value),
-  FOREIGN KEY (species_id) REFERENCES species(id)
+  FOREIGN KEY (species_id) REFERENCES species(id),
+  FOREIGN KEY (weapon_id) REFERENCES weapon(id)
 );
+
 
 -- type Person struct {
 -- 	Name      string   `json:"name"`

--- a/examples/swapi/model/swapi_model.generated.go
+++ b/examples/swapi/model/swapi_model.generated.go
@@ -2,24 +2,28 @@
 
 package model
 
-import "github.com/google/uuid"
+import (
+	"github.com/google/uuid"
+	"github.com/lumina-tech/gooq/pkg/nullable"
+)
 
 type ColorReferenceTable struct {
 	Value string `db:"value" json:"value"`
 }
 
 type Person struct {
-	ID        uuid.UUID `db:"id" json:"id"`
-	Name      string    `db:"name" json:"name"`
-	Height    float64   `db:"height" json:"height"`
-	Mass      float64   `db:"mass" json:"mass"`
-	HairColor Color     `db:"hair_color" json:"hair_color"`
-	SkinColor Color     `db:"skin_color" json:"skin_color"`
-	EyeColor  Color     `db:"eye_color" json:"eye_color"`
-	BirthYear int       `db:"birth_year" json:"birth_year"`
-	Gender    Gender    `db:"gender" json:"gender"`
-	HomeWorld string    `db:"home_world" json:"home_world"`
-	SpeciesID uuid.UUID `db:"species_id" json:"species_id"`
+	ID        uuid.UUID     `db:"id" json:"id"`
+	Name      string        `db:"name" json:"name"`
+	Height    float64       `db:"height" json:"height"`
+	Mass      float64       `db:"mass" json:"mass"`
+	HairColor Color         `db:"hair_color" json:"hair_color"`
+	SkinColor Color         `db:"skin_color" json:"skin_color"`
+	EyeColor  Color         `db:"eye_color" json:"eye_color"`
+	BirthYear int           `db:"birth_year" json:"birth_year"`
+	Gender    Gender        `db:"gender" json:"gender"`
+	HomeWorld string        `db:"home_world" json:"home_world"`
+	SpeciesID uuid.UUID     `db:"species_id" json:"species_id"`
+	WeaponID  nullable.UUID `db:"weapon_id" json:"weapon_id"`
 }
 
 type Species struct {
@@ -33,4 +37,10 @@ type Species struct {
 	EyeColor        Color     `db:"eye_color" json:"eye_color"`
 	HomeWorld       string    `db:"home_world" json:"home_world"`
 	Language        string    `db:"language" json:"language"`
+}
+
+type Weapon struct {
+	ID     uuid.UUID `db:"id" json:"id"`
+	Damage int       `db:"damage" json:"damage"`
+	Price  int       `db:"price" json:"price"`
 }

--- a/examples/swapi/table/swapi_table.generated.go
+++ b/examples/swapi/table/swapi_table.generated.go
@@ -84,6 +84,7 @@ type person struct {
 	Gender    gooq.StringField
 	HomeWorld gooq.StringField
 	SpeciesID gooq.UUIDField
+	WeaponID  gooq.UUIDField
 
 	Constraints *personConstraints
 }
@@ -112,6 +113,7 @@ func newPerson() *person {
 	instance.Gender = gooq.NewStringField(instance, "gender")
 	instance.HomeWorld = gooq.NewStringField(instance, "home_world")
 	instance.SpeciesID = gooq.NewUUIDField(instance, "species_id")
+	instance.WeaponID = gooq.NewUUIDField(instance, "weapon_id")
 	instance.Constraints = newPersonConstraints()
 	return instance
 }
@@ -219,3 +221,65 @@ func (t *species) ScanRows(
 }
 
 var Species = newSpecies()
+
+type weaponConstraints struct {
+	WeaponPkey gooq.DatabaseConstraint
+}
+
+type weapon struct {
+	gooq.TableImpl
+	Asterisk gooq.StringField
+	ID       gooq.UUIDField
+	Damage   gooq.IntField
+	Price    gooq.IntField
+
+	Constraints *weaponConstraints
+}
+
+func newWeaponConstraints() *weaponConstraints {
+	constraints := &weaponConstraints{}
+	constraints.WeaponPkey = gooq.DatabaseConstraint{
+		Name:      "weapon_pkey",
+		Predicate: null.NewString("", false),
+	}
+	return constraints
+}
+
+func newWeapon() *weapon {
+	instance := &weapon{}
+	instance.Initialize("public", "weapon")
+	instance.Asterisk = gooq.NewStringField(instance, "*")
+	instance.ID = gooq.NewUUIDField(instance, "id")
+	instance.Damage = gooq.NewIntField(instance, "damage")
+	instance.Price = gooq.NewIntField(instance, "price")
+	instance.Constraints = newWeaponConstraints()
+	return instance
+}
+
+func (t *weapon) As(alias string) *weapon {
+	instance := newWeapon()
+	instance.TableImpl = *instance.TableImpl.As(alias)
+	return instance
+}
+
+func (t *weapon) ScanRow(
+	db gooq.DBInterface, stmt gooq.Fetchable,
+) (*model.Weapon, error) {
+	result := model.Weapon{}
+	if err := gooq.ScanRow(db, stmt, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+func (t *weapon) ScanRows(
+	db gooq.DBInterface, stmt gooq.Fetchable,
+) ([]model.Weapon, error) {
+	results := []model.Weapon{}
+	if err := gooq.ScanRows(db, stmt, &results); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+var Weapon = newWeapon()

--- a/go.sum
+++ b/go.sum
@@ -9,7 +9,6 @@ github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+q
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/ScottyFillups/gOOQ v0.0.0-20191120092427-0a20cc180673 h1:+Ltuk/M/Ty2nj+pVZItzYsFvxUEbaZUZi2PbMqXj7jc=
 github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+sxIXdQ=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,7 @@ github.com/Microsoft/go-winio v0.4.14 h1:+hMXMk01us9KgxGb7ftKQt2Xpf5hH/yky+TDA+q
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
+github.com/ScottyFillups/gOOQ v0.0.0-20191120092427-0a20cc180673 h1:+Ltuk/M/Ty2nj+pVZItzYsFvxUEbaZUZi2PbMqXj7jc=
 github.com/agnivade/levenshtein v1.0.1 h1:3oJU7J3FGFmyhn8KHjmVaZCN5hxTr7GxgRue+sxIXdQ=
 github.com/agnivade/levenshtein v1.0.1/go.mod h1:CURSv5d9Uaml+FovSIICkLbAUZ9S4RqaHDIsdSBg7lM=
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=

--- a/pkg/nullable/jsonb.go
+++ b/pkg/nullable/jsonb.go
@@ -1,0 +1,66 @@
+package nullable
+
+import (
+	"database/sql/driver"
+)
+
+type Jsonb struct {
+	Jsonb []byte
+	Valid bool // Valid is true if Jsonb is not NULL
+}
+
+// JsonbFrom creates a new Jsonb that will never be blank.
+func JsonbFrom(value []byte) Jsonb {
+	jsonb := Jsonb{
+		Valid: value != nil,
+	}
+	if value != nil {
+		jsonb.Jsonb = make([]byte, len(value))
+		copy(jsonb.Jsonb, value)
+	}
+	return jsonb
+}
+
+func (self Jsonb) MarshalText() ([]byte, error) {
+	if !self.Valid {
+		return []byte{}, nil
+	}
+	return []byte(self.Jsonb), nil
+}
+
+func (self *Jsonb) UnmarshalText(data []byte) error {
+	str := string(data)
+	if str == "" {
+		self.Jsonb = nil
+		self.Valid = false
+		return nil
+	}
+	self.Valid = data != nil
+	self.Jsonb = data
+	return nil
+}
+
+// Scan implements the Scanner interface.
+func (self *Jsonb) Scan(v interface{}) error {
+	if v == nil {
+		self.Valid = false
+		return nil
+	}
+	switch x := v.(type) {
+	case []byte:
+		// must copy bytes to Jsonb.
+		// cannot just assign jsonb to v because v might be reused
+		self.Valid = true
+		self.Jsonb = make([]byte, len(x))
+		copy(self.Jsonb, x)
+	}
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (self Jsonb) Value() (driver.Value, error) {
+	if !self.Valid {
+		return nil, nil
+	}
+	return self.Jsonb, nil
+}

--- a/pkg/nullable/jsonb_test.go
+++ b/pkg/nullable/jsonb_test.go
@@ -1,0 +1,23 @@
+package nullable_test
+
+import (
+	"testing"
+
+	"github.com/lumina-tech/gooq/pkg/nullable"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonbScan(t *testing.T) {
+	bytes := []byte("hello world")
+	jsonb := nullable.JsonbFrom(nil)
+	require.False(t, jsonb.Valid)
+	require.Nil(t, jsonb.Jsonb)
+
+	err := jsonb.Scan(bytes)
+	require.NoError(t, err)
+	require.True(t, jsonb.Valid)
+	require.Equal(t, bytes, jsonb.Jsonb)
+
+	bytes[0] = byte('H')
+	require.NotEqual(t, bytes, jsonb.Jsonb)
+}

--- a/pkg/nullable/stringarray.go
+++ b/pkg/nullable/stringarray.go
@@ -1,0 +1,72 @@
+package nullable
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+
+	"github.com/lib/pq"
+)
+
+type StringArray struct {
+	StringArray pq.StringArray
+	Valid       bool // Valid is true if StringArray is not NULL
+}
+
+// StringArrayFrom creates a new StringArray that will never be blank.
+func StringArrayFrom(value []string) StringArray {
+	stringArray := StringArray{
+		Valid: value != nil,
+	}
+	if value != nil {
+		stringArray.StringArray = make([]string, len(value))
+		copy(stringArray.StringArray, value)
+	}
+	return stringArray
+}
+
+func (self StringArray) MarshalText() ([]byte, error) {
+	if !self.Valid {
+		return []byte{}, nil
+	}
+	bytes, err := json.Marshal(self.StringArray)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
+
+func (self *StringArray) UnmarshalText(data []byte) error {
+	if len(data) == 0 {
+		self.StringArray = nil
+		self.Valid = false
+		return nil
+	}
+	arr := make([]string, 0)
+	if err := json.Unmarshal(data, &arr); err != nil {
+		return err
+	}
+	self.Valid = true
+	self.StringArray = arr
+	return nil
+}
+
+// Scan implements the Scanner interface.
+func (self *StringArray) Scan(v interface{}) error {
+	if v == nil {
+		self.Valid = false
+		return nil
+	}
+	err := self.StringArray.Scan(v)
+	if err == nil {
+		self.Valid = true
+	}
+	return err
+}
+
+// Value implements the driver Valuer interface.
+func (self StringArray) Value() (driver.Value, error) {
+	if !self.Valid {
+		return nil, nil
+	}
+	return self.StringArray.Value()
+}

--- a/pkg/nullable/stringarray_test.go
+++ b/pkg/nullable/stringarray_test.go
@@ -1,0 +1,46 @@
+package nullable_test
+
+import (
+	"testing"
+
+	"github.com/lib/pq"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/lumina-tech/gooq/pkg/nullable"
+)
+
+func TestStringArrayScan(t *testing.T) {
+	stringArray := nullable.StringArrayFrom(nil)
+	require.False(t, stringArray.Valid)
+	require.Nil(t, stringArray.StringArray)
+
+	bytes := []byte("{\"hello\",\"world\"}")
+	err := stringArray.Scan(bytes)
+	require.NoError(t, err)
+	require.True(t, stringArray.Valid)
+	require.Equal(t, pq.StringArray{"hello", "world"}, stringArray.StringArray)
+
+	value, err := stringArray.Value()
+	require.NoError(t, err)
+	require.Equal(t, string(bytes), value)
+}
+
+func TestStringArrayMarshalText(t *testing.T) {
+	stringArray := nullable.StringArrayFrom([]string{"test"})
+
+	err := stringArray.UnmarshalText(nil)
+	require.NoError(t, err)
+	require.False(t, stringArray.Valid)
+	require.Nil(t, stringArray.StringArray)
+
+	text := []byte("[\"hello\",\"world\"]")
+	err = stringArray.UnmarshalText(text)
+	require.NoError(t, err)
+	require.True(t, stringArray.Valid)
+	require.Equal(t, pq.StringArray{"hello", "world"}, stringArray.StringArray)
+
+	marshalled, err := stringArray.MarshalText()
+	require.NoError(t, err)
+	require.Equal(t, text, marshalled)
+}

--- a/pkg/nullable/uuid.go
+++ b/pkg/nullable/uuid.go
@@ -1,0 +1,139 @@
+package nullable
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	fmt "fmt"
+	"reflect"
+
+	"github.com/google/uuid"
+)
+
+// UUID is a nullable UUID. It supports SQL and JSON serialization.
+// It will marshal to null if null. Blank UUID input will be considered null.
+type UUID struct {
+	uuid.UUID
+	Valid bool // Valid is true if String is not NULL
+}
+
+// newUUID creates a new UUID
+func newUUID(value uuid.UUID) UUID {
+	return UUID{
+		UUID:  value,
+		Valid: value != uuid.Nil,
+	}
+}
+
+// UUIDFrom creates a new UUID that will never be blank.
+func UUIDFrom(v uuid.UUID) UUID {
+	return newUUID(v)
+}
+
+// UUIDFromPtr creates a new UUID that be null if s is nil.
+func UUIDFromPtr(v *uuid.UUID) UUID {
+	if v == nil {
+		return newUUID(uuid.Nil)
+	}
+	return newUUID(*v)
+}
+
+// Scan implements the Scanner interface.
+func (u *UUID) Scan(v interface{}) error {
+	if v == nil {
+		u.Valid = false
+		return nil
+	}
+	switch x := v.(type) {
+	case []byte:
+		value, err := uuid.Parse(string(x))
+		if err != nil {
+			return err
+		}
+		u.Valid = value != uuid.Nil
+		u.UUID = value
+	}
+	return nil
+}
+
+// Value implements the driver Valuer interface.
+func (u UUID) Value() (driver.Value, error) {
+	if !u.Valid {
+		return nil, nil
+	}
+	return u.UUID.String(), nil
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this UUID is null.
+func (u UUID) MarshalJSON() ([]byte, error) {
+	if !u.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(u.UUID)
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports UUID and null input. Blank UUID input does not produce a null UUID.
+// It also supports unmarshalling a sql.UUID.
+func (u *UUID) UnmarshalJSON(data []byte) error {
+	var v interface{}
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch x := v.(type) {
+	case string:
+		value, err := uuid.Parse(x)
+		if err != nil {
+			return err
+		}
+		u.Valid = value != uuid.Nil
+		u.UUID = value
+		return nil
+	case nil:
+		u.Valid = false
+		u.UUID = uuid.Nil
+		return nil
+	}
+	return fmt.Errorf("json: cannot unmarshal %v into Go value of type null.UUID", reflect.TypeOf(v).Name())
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a blank UUID when this UUID is null.
+func (u UUID) MarshalText() ([]byte, error) {
+	if !u.Valid {
+		return []byte{}, nil
+	}
+	return []byte(u.UUID.String()), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null UUID if the input is a blank UUID.
+func (u *UUID) UnmarshalText(text []byte) error {
+	str := string(text)
+	if str == "" {
+		u.UUID = uuid.Nil
+		u.Valid = false
+		return nil
+	}
+	value, err := uuid.Parse(string(text))
+	if err != nil {
+		return err
+	}
+	u.Valid = value != uuid.Nil
+	u.UUID = value
+	return nil
+}
+
+// SetValue changes this UUID's value and also sets it to be non-null.
+func (u *UUID) SetValue(value uuid.UUID) {
+	u.UUID = value
+	u.Valid = value != uuid.Nil
+}
+
+// Ptr returns a pointer to this UUID's value, or a nil pointer if this UUID is null.
+func (u UUID) Ptr() *uuid.UUID {
+	if !u.Valid {
+		return nil
+	}
+	return &u.UUID
+}

--- a/pkg/nullable/uuid_test.go
+++ b/pkg/nullable/uuid_test.go
@@ -1,0 +1,111 @@
+package nullable_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/lumina-tech/gooq/pkg/nullable"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	nilJSON       = []byte(`"00000000-0000-0000-0000-000000000000"`)
+	uuidJSON      = []byte(`"4925be64-f5dc-4a49-a682-98134ca5286d"`)
+	blankUUIDJSON = []byte(`""`)
+	nullJSON      = []byte(`null`)
+	invalidJSON   = []byte(`:)`)
+	boolJSON      = []byte(`true`)
+)
+
+type stringInStruct struct {
+	Test nullable.UUID `json:"test,omitempty"`
+}
+
+func TestUUIDFrom(t *testing.T) {
+	uuid1, _ := uuid.Parse("4925be64-f5dc-4a49-a682-98134ca5286d")
+	u := nullable.UUIDFrom(uuid1)
+	require.True(t, u.Valid)
+	require.Equal(t, uuid1, u.UUID)
+
+	// test nil case
+	u = nullable.UUIDFrom(uuid.Nil)
+	require.False(t, u.Valid)
+	require.Equal(t, uuid.Nil, u.UUID)
+}
+
+func TestUUIDFromPtr(t *testing.T) {
+	uuid1, _ := uuid.Parse("4925be64-f5dc-4a49-a682-98134ca5286d")
+	uptr := &uuid1
+	u := nullable.UUIDFromPtr(uptr)
+	require.True(t, u.Valid)
+	require.Equal(t, uuid1, u.UUID)
+
+	u = nullable.UUIDFromPtr(&uuid.Nil)
+	require.False(t, u.Valid)
+
+	u = nullable.UUIDFromPtr(nil)
+	require.False(t, u.Valid)
+}
+
+func TestUnmarshalUUID(t *testing.T) {
+	expected, _ := uuid.Parse("4925be64-f5dc-4a49-a682-98134ca5286d")
+
+	var u nullable.UUID
+	err := json.Unmarshal(uuidJSON, &u)
+	require.NoError(t, err)
+	require.True(t, u.Valid)
+	require.Equal(t, expected, u.UUID)
+
+	var blank nullable.UUID
+	err = json.Unmarshal(blankUUIDJSON, &blank)
+	require.Error(t, err)
+	require.False(t, blank.Valid)
+	require.Equal(t, uuid.Nil, blank.UUID)
+
+	var nilUUID nullable.UUID
+	err = json.Unmarshal(nilJSON, &nilUUID)
+	require.NoError(t, err)
+	require.False(t, nilUUID.Valid)
+	require.Equal(t, uuid.Nil, nilUUID.UUID)
+
+	var null nullable.UUID
+	err = json.Unmarshal(nullJSON, &null)
+	require.NoError(t, err)
+	require.False(t, null.Valid)
+	require.Equal(t, uuid.Nil, null.UUID)
+
+	var badType nullable.UUID
+	err = json.Unmarshal(boolJSON, &badType)
+	require.Error(t, err)
+	require.False(t, badType.Valid)
+	require.Equal(t, uuid.Nil, badType.UUID)
+
+	var invalid nullable.UUID
+	err = invalid.UnmarshalJSON(invalidJSON)
+	require.Error(t, err)
+	require.False(t, invalid.Valid)
+	require.Equal(t, uuid.Nil, invalid.UUID)
+}
+
+func TestTextUnmarshalUUID(t *testing.T) {
+	uuid1, _ := uuid.Parse("4925be64-f5dc-4a49-a682-98134ca5286d")
+
+	var u nullable.UUID
+	err := u.UnmarshalText([]byte(uuid1.String()))
+	require.NoError(t, err)
+	require.True(t, u.Valid)
+	require.Equal(t, uuid1, u.UUID)
+
+	var nilUUID nullable.UUID
+	err = nilUUID.UnmarshalText([]byte("00000000-0000-0000-0000-000000000000"))
+	require.NoError(t, err)
+	require.False(t, nilUUID.Valid)
+	require.Equal(t, uuid.Nil, nilUUID.UUID)
+
+	var null nullable.UUID
+	err = null.UnmarshalText([]byte(""))
+	require.NoError(t, err)
+	require.False(t, null.Valid)
+	require.Equal(t, uuid.Nil, null.UUID)
+}


### PR DESCRIPTION
gOOQ uses `nullable.UUID` to express UUIDs that can be NULL. Unfortunately, the nullable package isn't in this repository, which means it's impossible to have NULL UUIDs in your schema.

This PR:
* Adds the nullable package to `/pkg/nullable`
* Modifies the example schema in `/examples/swapi` to include a nullable UUID
* Updates the generated files in the example